### PR TITLE
Add backend setup script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Sheets/Forms → Apps Script → HTTPS endpoint → Firestore
 ## Quick start
 
 ### 1) Backend (Cloud Functions/Run)
-Implement an HTTPS endpoint that validates a shared secret or IAM and writes to Firestore. A minimal Node sample is in [`server/index.js`](#serverindexjs). Deploy it and record its URL.
+Run the provided setup script to deploy the sample backend:
+
+```
+./scripts/setup-backend.sh
+```
+
+It will prompt for your Firebase project ID, store the `APP_SECRET`, enable required APIs, and deploy the `adminAddDoc` function.
+
+Prefer to roll your own? Implement an HTTPS endpoint that validates a shared secret or IAM and writes to Firestore. A minimal TypeScript sample is in [`functions/index.ts`](functions/index.ts).
 
 ### 2) Apps Script (the bridge)
 - Create/open your Google Sheet

--- a/scripts/setup-backend.sh
+++ b/scripts/setup-backend.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to repository root
+cd "$(dirname "$0")/.."
+
+read -rp "Firebase project ID: " PROJECT_ID
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "Project ID is required" >&2
+  exit 1
+fi
+
+# Set secret in Firebase Functions
+firebase functions:secrets:set APP_SECRET --project "$PROJECT_ID"
+
+# Enable required APIs
+gcloud services enable firestore.googleapis.com cloudfunctions.googleapis.com --project "$PROJECT_ID"
+
+# Deploy the adminAddDoc function
+firebase deploy --config functions/firebase.json --only functions:adminAddDoc --project "$PROJECT_ID"


### PR DESCRIPTION
## Summary
- add `scripts/setup-backend.sh` for Firebase backend setup
- document how to use the setup script

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm --prefix functions test` *(fails: Missing script "test")*
- `npm --prefix functions run build` *(fails: No inputs were found in config file)*

